### PR TITLE
Improve syft scanning times and skip internet calls to check for updates

### DIFF
--- a/syft/syft.go
+++ b/syft/syft.go
@@ -27,6 +27,8 @@ import (
 	"github.com/paketo-buildpacks/libpak/crush"
 )
 
+const UpdateCheckEnvVar = "SYFT_CHECK_FOR_APP_UPDATE"
+
 type Syft struct {
 	LayerContributor libpak.DependencyLayerContributor
 	Logger           bard.Logger
@@ -58,7 +60,9 @@ func (w Syft) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		if err := os.Symlink(filepath.Join(layer.Path, "syft"), filepath.Join(binDir, "syft")); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to symlink Syft\n%w", err)
 		}
-
+		// We should skip checking for version updates for syft. This causes timeouts and slowdowns
+		// in air-gapped environments.
+		layer.BuildEnvironment.Default(UpdateCheckEnvVar, "false")
 		return layer, nil
 	})
 }

--- a/syft/syft_test.go
+++ b/syft/syft_test.go
@@ -17,6 +17,7 @@
 package syft_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -65,7 +66,7 @@ func testSyft(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.LayerTypes.Build).To(BeTrue())
 		Expect(layer.LayerTypes.Cache).To(BeTrue())
 		Expect(layer.LayerTypes.Launch).To(BeFalse())
-
+		Expect(layer.BuildEnvironment).To(HaveKeyWithValue(fmt.Sprintf("%s.default", syft.UpdateCheckEnvVar), "false"))
 		Expect(filepath.Join(layer.Path, "syft")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "bin", "syft")).To(BeAnExistingFile())
 	})


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

The buildpack downloads a specific version of syft and we will not be doing build time updates for syft. We should disable syft's default check for app updates as it causes delays during scans and requires reaching out to the internet.