### PR TITLE
Generate label-based BOM for all API versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/buildpacks/libcnb v1.25.5
 	github.com/onsi/gomega v1.18.1
-	github.com/paketo-buildpacks/libpak v1.57.1
+	github.com/paketo-buildpacks/libpak v1.58.0
 	github.com/sclevine/spec v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/buildpacks/libcnb v1.25.2/go.mod h1:XX0+zHW8CNLNwiiwowgydAgWWfyDt8Lj1NcuWtkkBJQ=
 github.com/buildpacks/libcnb v1.25.5 h1:D8UoXv39+0jkG4M+u/pfxYjLWZMOQv1TH6dZDRFpVsg=
 github.com/buildpacks/libcnb v1.25.5/go.mod h1:KUVN17jE9c+iLqz8FHwfYyCEossLkKEbz1ixPYqwFNI=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -57,8 +55,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/paketo-buildpacks/libpak v1.57.1 h1:Rqq25boRl95WWW10Au8/krEQqZyU8KT4AZocTQxCwBA=
-github.com/paketo-buildpacks/libpak v1.57.1/go.mod h1:RqGprj975LOMoH00DjbHcOabU7fOpyVVtOTI+3jhWrU=
+github.com/paketo-buildpacks/libpak v1.58.0 h1:tId115h3SZn8IY8DQxRF36PwhMob4G9TVkWWDTD9MKY=
+github.com/paketo-buildpacks/libpak v1.58.0/go.mod h1:qxRaH+WrJYWEb4FZqYkMR9mdyNEsrNOq7bE7O4dXH1k=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/syft/build.go
+++ b/syft/build.go
@@ -56,9 +56,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		syft, be := NewSyft(syftDependency, dc)
 
 		result.Layers = append(result.Layers, syft)
-		if be.Name != "" {
-			result.BOM.Entries = append(result.BOM.Entries, be)
-		}
+		result.BOM.Entries = append(result.BOM.Entries, be)
 	}
 
 	return result, nil

--- a/syft/build_test.go
+++ b/syft/build_test.go
@@ -91,6 +91,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("syft"))
 
-		Expect(result.BOM.Entries).To(HaveLen(0))
+		Expect(result.BOM.Entries).To(HaveLen(1))
+		Expect(result.BOM.Entries[0].Name).To(Equal("syft"))
 	})
 }


### PR DESCRIPTION
## Summary

Starting with lifecycle 0.13.3, it is permitted to have both the old style label-based BOM information and the new style layer-based BOM information. If the buildpack API is 0.6 or older, label-based BOMs only is OK. If the buildpack API is 0.7, you may have both label-based BOM and layer-based BOM or just layer-based BOM. It is permitted to have just label-based BOM, however, that will generate a warning from the lifecycle.

The libpak library was adjusted to support this. This change updates to remove unnecessary if checks and updates tests to pass.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
