### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/syft`
 
-The Paketo Syft Buildpack is a Cloud Native Buildpack that contributes the Syft CLI which can be used to generate SBoM information.
+The Paketo Buildpack for Syft is a Cloud Native Buildpack that contributes the Syft CLI which can be used to generate SBoM information.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/syft"
   id = "paketo-buildpacks/syft"
   keywords = ["bom", "sbom", "bill of materials", "syft"]
-  name = "Paketo Syft Buildpack"
+  name = "Paketo Buildpack for Syft"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Syft Buildpack' to 'Paketo Buildpack for Syft'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
