### PR TITLE
Implement RFC 0044: Provide Global Mechanism to Disable SBOM Generation

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -31,6 +31,12 @@ api = "0.7"
   include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
+  [[metadata.configurations]]
+    build = true
+    default = "false"
+    description = "disables generation of SBOM documents during the build process"
+    name = "BP_DISABLE_SBOM"
+
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:anchore:syft:0.101.0:*:*:*:*:*:*:*"]
     id = "syft"

--- a/syft/build.go
+++ b/syft/build.go
@@ -32,6 +32,19 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	b.Logger.Title(context.Buildpack)
 	result := libcnb.NewBuildResult()
 
+	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
+	}
+
+	if cr.ResolveBool("BP_DISABLE_SBOM") {
+		result.Labels = append(result.Labels, libcnb.Label{
+			Key:   "io.paketo.sbom.disabled",
+			Value: "true",
+		})
+		return result, nil
+	}
+
 	dc, err := libpak.NewDependencyCache(context)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create dependency cache\n%w", err)


### PR DESCRIPTION

## Summary

Implement [RFC 0044](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0044-disable-sbom.md) by checking for `BP_DISABLE_SBOM` as one of the first things in `build.go` and, if set, return early.

**Alternatives considered**
- Change `detect.go` to bail out, if `BP_DISABLE_SBOM` is set. I guess that would be the more "idiomatic" way of doing it, but:
  - It breaks other buildpacks requiring `syft` as no one will provide `syft` anymore. This could be fixed, by making sure other buildpacks only require `syft`, if `BP_DISABLE_SBOM` is not set, but I don't think that's worth it.
  - There is no chance to set the `io.paketo.sbom.disabled` label (AFAIK) as suggested by the RFC (this could also be moved to other buildpacks, but again I don't think that's worth it ).

**Open Questions**
Should the buildpack log that sbom generation is skipped? After all that is its only purpose, so might be worth logging.

## Use Cases

See [RFC 0044](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0044-disable-sbom.md)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
